### PR TITLE
调整斜体的字体，调整粗体和粗斜颜色，增加英文系统的字体适配

### DIFF
--- a/source/css/sass/_base_style.sass
+++ b/source/css/sass/_base_style.sass
@@ -28,12 +28,15 @@ body
   background-position: 50% 40px
   background-repeat: no-repeat
   background-size: cover
-  font-family: "JetBrains Mono", sans-serif
+  font-family: "JetBrains Mono", 'Microsoft YaHei', '\5b8b\4f53', sans-serif
   display: flex
   flex-direction: column
   align-items: stretch
 
-h1, h2, h3, h4, h5, h6
+h1
+  color: #fe2
+
+h2, h3, h4, h5, h6
   color: #fff
 
 a
@@ -53,9 +56,11 @@ time
 
 code, pre
   font-family: "JetBrains Mono"
+
 code
   background-color: rgba(#fff, .1)
   padding: 0 3px
+
 pre
   background-color: transparent
 
@@ -68,7 +73,15 @@ kbd
   font-family: "JetBrains Mono"
 
 strong em
-  color: rgb(236, 48, 0)
+  font-family: "JetBrains Mono", 'Microsoft YaHei', '\5b8b\4f53', sans-serif
+  color: #C0392B
+
+strong
+  color: #FFFFFF
+
+em
+  font-family: Times, "Times New Roman", 'FangSong', 'SimSun', serif
+  color: #949494
 
 blockquote
   border-left: #2bf solid 5px


### PR DESCRIPTION
斜体字体设置为仿宋和times（适合英文书名和人名），颜色相比正文调暗了一点#949494
粗体颜色设置为纯白#FFFFFF
粗斜体的红色更新为略暗一点的#C0392B

增加了font-family中的备选字体，以适配英文系统的浏览器

标题的h1改成黄色，尽管与明日方舟官网有所出入，但可以提升视觉效果