### PR TITLE
页面视图修正

### DIFF
--- a/layout/includes/layout.pug
+++ b/layout/includes/layout.pug
@@ -112,8 +112,8 @@ html(lang=config.language)
                   #total-categories
                     span.total-title Categories:
                     span.total-number= site.categories.length
-          #aside-block(style= asideBlock)
-            block aside-block
+            #aside-block(style= asideBlock)
+              block aside-block
           footer(style=footerStyle)
             if theme.aside.copyright !== null
               each content, title in theme.aside.copyright

--- a/source/css/sass/_flex_layout.sass
+++ b/source/css/sass/_flex_layout.sass
@@ -6,12 +6,16 @@
   main
     flex-direction: column
     overflow-y: auto
+    .aside-box
+      width: 100%
+      max-width: 100%
     article
       border: none
       width: 100%
       max-height: none
       padding: 0
       flex-shrink: 0
+      max-width: 100%
   .highlight, blockquote
     margin: 0
   aside

--- a/source/css/sass/layout/__main_article.sass
+++ b/source/css/sass/layout/__main_article.sass
@@ -1,6 +1,6 @@
 article
-  // 确保内容页的最大宽度为1600-310px 1600为main的最大宽度 310为侧边栏的宽度
-  max-width: 1290px
+  // 确保内容页的最大宽度为main的80%
+  max-width: 80%
   min-height: calc(100% - 10px)
   height: fit-content
   .right &

--- a/source/css/sass/layout/__main_aside.sass
+++ b/source/css/sass/layout/__main_aside.sass
@@ -90,7 +90,7 @@ footer
     font-size: medium
 
 .aside-box
-    flex-shrink: 0;
+    flex-shrink: 0
     width: 310px
     height: 95%
 

--- a/source/css/sass/layout/__main_aside.sass
+++ b/source/css/sass/layout/__main_aside.sass
@@ -91,8 +91,8 @@ footer
 
 .aside-box
     flex-shrink: 0
-    width: 310px
-    height: 95%
+    width: 20%
+    height: calc(100% - 40px)
 
 #description p
   margin: unset

--- a/source/css/sass/layout/__main_aside.sass
+++ b/source/css/sass/layout/__main_aside.sass
@@ -90,6 +90,7 @@ footer
     font-size: medium
 
 .aside-box
+    flex-shrink: 0;
     width: 310px
     height: 95%
 


### PR DESCRIPTION
修复小屏幕下侧栏因为没有媒体查询导致混乱
修改页面元素的固定值变为百分比从而提高页面整体协调性
tips：文章点进去后section#total元素不会正常消失，刷新后会正常消失但首页也会消失 待修复