### PR TITLE
Add support for dynamic rendering MathJax

### DIFF
--- a/README-Ja.md
+++ b/README-Ja.md
@@ -8,6 +8,7 @@
 - **Dr.Ye: <https://laurenfrost.github.io/>**
 - **Dr.LingYun: <https://dr-lingyun.gitee.io/>**
 - **Dr.hastin: <http://hastin-blog.cn/>**
+- **Dr.Ryo <https://blog.ryo-okami.xyz/>**
 
 このテーマを使ったあなたのブログリンク、ここに付けたいなら大歓迎~　　
 
@@ -106,9 +107,13 @@ yarn add hexo-server hexo-browsersync hexo-renderer-pug
 
 メールサブスクライブ：[zhaojun1998 / Valine-Admin](https://github.com/zhaojun1998/Valine-Admin)。  
 
-## 数式および方程式の作成
-このテーマは数式および方程式を書類に含めることができます。  
-数式を作成するために、[hexo-filter-mathjax](https://github.com/next-theme/hexo-filter-mathjax) というフィルターが使用されています。  
+## 数式および方程式の表示
+
+このテーマでは、数式表示には二つの方法があります。
+
+### その1：静的生成
+
+数式を表示するために、[hexo-filter-mathjax](https://github.com/next-theme/hexo-filter-mathjax) というフィルターが使用されています。  
 
 1. まずは `<Hexo>` で以下のコマンドを実行します： 
 
@@ -131,7 +136,7 @@ mathjax:
   every_page: false #  true に設定されると、記事の頭の `mathjax` の値を問わずに、 mathjax が使用される
 ```
 
-3. mathjax を使用したい記事の [Front-matter](https://hexo.io/zh-cn/docs/front-matter) に `mathjax: true` を追加すると：
+3. mathjax を利用したい記事の [Front-matter](https://hexo.io/zh-cn/docs/front-matter) に `mathjax: true` を追加すると：
 ```markdown
 ---
 title: On the Electrodynamics of Moving Bodies
@@ -150,7 +155,7 @@ mathjax: true
 +$\frac{\partial}{\partial t}$
 ```
 
-5. LaTeX と Markdown の文法の差異にご注意ください。必要とされる時は半角のバックスラッシュ `\` （日本語環境では半角円記号 '¥'）を文字の前に付けましょう：
+5. LaTeX と Markdown の文法の差異にご注意ください。必要とされる時は半角のバックスラッシュ `\` （日本語環境では半角円記号 '¥'）でエスケープしてください：
 ```diff
 -$\epsilon_0$
 +$\epsilon\_0$
@@ -158,7 +163,48 @@ mathjax: true
 +\begin{eqnarray\*}
 ```
 
-> さらに効果の高い数式プラグイン [hexo-renderer-pandoc](https://github.com/wzpan/hexo-renderer-pandoc) の使用はまだ検討中です。
+> エスケープせずよりよく数式レンダリングするために、プラグイン [hexo-renderer-pandoc](https://github.com/wzpan/hexo-renderer-pandoc) の使用も推奨されています。
+
+### その2：動的レンダリング
+
+このテーマでは、[MathJax](https://www.mathjax.org/)を利用して、数式をブラウザサイドで動的レンダリングすることもできます。
+
+1. まずは、デフォルトのレンダラー hexo-renderer-marked をアンインストールし、その代わりとして [hexo-renderer-kramed](https://github.com/sun11/hexo-renderer-kramed) をインストールします。
+   ```shell
+   $ npm uninstall hexo-renderer-marked --save
+   $ npm install hexo-renderer-kramed --save
+   ```
+2. また、 `<Hexo>/_config.yml` を、以下のように変更します。
+   ```diff
+    mathjax:
+   -  enable: false
+   +  enable: true
+      version: '2.6.1'
+   ```
+3. そして、記事の中で以下のように LaTeX 文法を利用して、数式を表示出来ます。
+   ```latex
+   % インライン数式
+   % 両側に「`」を付けてください。「`」と「$」の間に隙間あってはいけません。
+   `$\sigma$`
+
+   % ディスプレイ数式
+   $$
+   \begin{aligned}f(x) &= \sum_{i=1}^{\infty}{\frac{x}{2^i}} \\
+   &= x\end{aligned}
+   $$
+   ```
+4. この方法を使うと、 LaTeX と Markdown の文法の差を気にせずに数式を書くことができます。
+   以下のように数式を書いても、何の問題もなくレンダリングされます。
+   ```latex
+   \epsilon_0
+   \begin{eqnarray*}
+   ```
+レンダラー hexo-renderer-marked は他の設定もできますので、公式ドキュメントを参考にしてみてください：https://github.com/sun11/hexo-renderer-kramed
+
+以上の方法は、それぞれに長所と短所があります：
+1. 動的レンダリングは、 LaTeX 文法のエスケープせずに書くことができる為、他のフレームワークやブログサイトからの記事導入は簡単にできます。ですが、クライアントサイドレンダリングですので、ページ上の数式表示は若干遅れます。
+2. 静的生成は、数式を素早く表示することができますが、 LaTeX 文法のエスケープをしなくてはいけません。
+3. [hexo-renderer-pandoc](https://github.com/wzpan/hexo-renderer-pandoc) を利用して、文法をエスケープする手間がかからなくても、数式を素早く表示できますが、 Pandoc をインストールしなくてはいけません。
 
 ## テーマの開発にあなたの力を
 ### メンバー

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **Dr.XIMU：<http://b.ligzs.cn/>**
 - **Dr.ToUNVRSe <https://tounvrse.github.io/>**
 - **Dr.tyqtyq <https://tyq0712.github.io/>**
+- **Dr.Ryo <https://blog.ryo-okami.xyz/>**
 
 如果使用了这个主题，欢迎在这儿贴预览链接~
 
@@ -143,7 +144,11 @@ gitalk:
 
 ## 数学公式
 
-使用 [hexo-filter-mathjax](https://github.com/next-theme/hexo-filter-mathjax) Hexo 过滤器来显示数学公式：
+本主题支持两种方案显示数学公式：
+
+### 方案一：静态渲染
+
+可以使用 [hexo-filter-mathjax](https://github.com/next-theme/hexo-filter-mathjax) Hexo 过滤器静态渲染，来显示数学公式：
 
 1. 在 Hexo 目录下执行以下指令：
 
@@ -198,6 +203,51 @@ mathjax: true
 ```
 
 > 也可以尝试更换能更好处理数学公式的渲染器 [hexo-renderer-pandoc](https://github.com/wzpan/hexo-renderer-pandoc)
+
+### 方案二：动态渲染
+
+本主题也支持 [MathJax](https://www.mathjax.org/) ，在用户浏览时动态渲染公式：
+
+1. 首先要卸载 Hexo 默认自带的 hexo-renderer-marked 渲染器，更换成对 MathJax 支持更好的 [hexo-renderer-kramed](https://github.com/sun11/hexo-renderer-kramed) 渲染器：
+   ```shell
+   $ npm uninstall hexo-renderer-marked --save
+   $ npm install hexo-renderer-kramed --save
+   ```
+2. 修改 **Hexo 目录** 下的 `_config.arknights.yml` 文件：
+   ```diff
+    # 公式支持
+    mathjax:
+   -  enable: false
+   +  enable: true
+      version: '2.6.1'
+   ```
+3. 然后，就可以在文章中使用 LaTeX 语法：
+   ```latex
+   % 单行内联公式
+   % 注意需要两边带上 "`" ，且 "`" 与 "$" 之间不能有空格
+   `$\sigma$`
+
+   % 多行公式
+   $$
+   \begin{aligned}f(x) &= \sum_{i=1}^{\infty}{\frac{x}{2^i}} \\
+   &= x\end{aligned}
+   $$
+   ```
+4. 用这种方案，不会造成 LaTeX 与 Markdown 语法之间的冲突。在文中使用 LaTeX 语法不需要转义。
+   以下公式可以直接使用，不会造成任何问题：
+   ```latex
+   \epsilon_0
+   \begin{eqnarray*}
+   ```
+
+hexo-renderer-kramed 插件还有其他可配置项，请参考插件文档： https://github.com/sun11/hexo-renderer-kramed
+
+
+几种公式显示方案各有优缺点：
+1. 动态渲染方案 LaTeX 语法不需要转义，能更好的支持从其他地方导出的 Markdown 文件。但因为需要在浏览器渲染，页面显示会略有延迟。
+2. 静态渲染方案将公式直接编译在静态文件里，显示性能更优，但语法需要转义。
+3. 使用 [hexo-renderer-pandoc](https://github.com/wzpan/hexo-renderer-pandoc) 兼顾显示性能与无需转义两者的特点，但需要在环境中另外安装 pandoc 转换器。
+
 
 ## 图表支持
 

--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,11 @@ pjax:
   enable: false
   version: '0.2.8'
 
+# 公式支持
+mathjax:
+  enable: false
+  version: '2.6.1'
+
 # main menu navigation
 menu:
   Home: ''

--- a/layout/includes/layout.pug
+++ b/layout/includes/layout.pug
@@ -44,6 +44,27 @@ html(lang=config.language)
         |   startOnLoad: false
         |   , theme: 'dark'
         | });
+    if theme.mathjax.enable === true
+      script(src="//cdnjs.cloudflare.com/ajax/libs/mathjax/" + theme.mathjax.version + "/MathJax.js")
+      script
+        | MathJax.Hub.Config({
+        |   menuSettings: {
+        |     zoom: "None"
+        |   },
+        |   showMathMenu: false,
+        |   jax: ["input/TeX","output/CommonHTML"],
+        |   extensions: ["tex2jax.js"],
+        |   TeX: {
+        |     extensions: ["AMSmath.js","AMSsymbols.js"],
+        |     equationNumbers: {
+        |       autoNumber: "AMS"
+        |     }
+        |   },
+        |   tex2jax: {
+        |     inlineMath: [["\\(", "\\)"]],
+        |     displayMath: [["\\[", "\\]"]]
+        |   }
+        | });
     link(rel="stylesheet", href=config.root + "css/arknights.css")
     if theme.stylesheets !== undefined && theme.stylesheets.length > 0
       //- stylesheets list from _config.yml


### PR DESCRIPTION
添加一种可选的渲染公式的方案支持。

1. 模板中添加可选的 MathJax 导入支持，配置文件中增加相应设置项，并更新中日语相关文档。
2. 修复了日语文档上下文中一些语义错误。

> 我需要从其他地方导入一些文章，用原来方案的话公式全部都需要转义太难受了，就添加了这种不需要转义的方案。

> 使用样例：https://blog.ryo-okami.xyz/2021/01/11/2021-01-11-Sort-algorithm/