### PR TITLE
修复设置中缺少某些字段报错的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/package-lock.json

--- a/layout/includes/layout.pug
+++ b/layout/includes/layout.pug
@@ -30,20 +30,20 @@ html(lang=config.language)
     meta(charset='UTF-8')
     meta(name='viewport' content='width=device-width, initial-scale=1.0')
     title= pageTitle
-    if theme.valine.enable === true
+    if theme.valine !== undefined && theme.valine.enable === true
       script(src='//unpkg.com/valine/dist/Valine.min.js')
     if searchConfig
       script var config = !{configs}
-    if theme.gitalk.enable === true
+    if theme.gitalk !== undefined && theme.gitalk.enable === true
       script(src=config.root + "js/gitalk.js")
-    if theme.mermaid.enable === true && theme.mermaid.version !== undefined
+    if theme.mermaid !== undefined && theme.mermaid.enable === true && theme.mermaid.version !== undefined
       script(src= "//unpkg.com/mermaid@" + theme.mermaid.version + "/dist/mermaid.min.js")
       script
         |mermaid.initialize({
         |  startOnLoad: true
         |  , theme: 'dark'
         |});
-    if theme.mathjax.enable === true
+    if theme.mathjax !== undefined && theme.mathjax.enable === true
       script(src="//cdnjs.cloudflare.com/ajax/libs/mathjax/" + theme.mathjax.version + "/MathJax.js")
       script
         |MathJax.Hub.Config({
@@ -104,7 +104,7 @@ html(lang=config.language)
     if searchConfig !== null
       script(src="/js/search.js")
     script.pjax-js reset=_=>{
-      if theme.valine.enable === true
+      if theme.valine !== undefined && theme.valine.enable === true
         |new Valine({
         |  el: '#Valine'
         |  , appId: '#{appID}'
@@ -113,7 +113,7 @@ html(lang=config.language)
           | , serverURLs: '#{theme.valine.server_url}'
         |  , placeholder: '此条评论委托企鹅物流发送'
         |});
-      if theme.gitalk.enable === true
+      if theme.gitalk !== undefined && theme.gitalk.enable === true
         - let config = theme.gitalk, gitAdmin = ''
         for str in theme.gitalk.admin
           - gitAdmin= gitAdmin + "'" + str + "'"


### PR DESCRIPTION
例如，我的配置文件里没有mathjax这一整个块（我不想启用这个功能），主题就会报“cannot read properties of undefined”。
同时加了一个gitignore，建议把它放在仓库里而不是忽略它，这样其他人用起来方便