### PR TITLE
fix: i18n typo in zh-cn.yml

### DIFF
--- a/languages/zh-cn.yml
+++ b/languages/zh-cn.yml
@@ -11,7 +11,7 @@ busuanzi:
   loading: "加载中..."
   siteView: "总访问量："
   siteVisitor: "访客数："
-  pageView: "页面浏览："
+  pageView: "页面浏览: "
 
 post:
   posted: "文章发布时间: "


### PR DESCRIPTION
混用的半角和全角冒号导致视觉不统一。如图：
![PixPin_2024-02-05_00-22-17](https://github.com/Yue-plus/hexo-theme-arknights/assets/77579735/91ce9852-a8b4-44fa-9a4d-f07b951c1650)
将原来的全角冒号修改为半角冒号和空格，以和发布时间、修改时间、字数统计的视觉相统一。