### PR TITLE
fix. 修复mathjax无法显示的问题

### DIFF
--- a/layout/includes/js-data.pug
+++ b/layout/includes/js-data.pug
@@ -24,7 +24,7 @@ if theme.waline && theme.waline.enable === true
     window.waline = init;
 
 if theme.mathjax && theme.mathjax.enable === true
-  script(async src="//cdnjs.cloudflare.com/ajax/libs/mathjax/" + theme.mathjax.version + "/MathJax.js")
+  script(src="//cdnjs.cloudflare.com/ajax/libs/mathjax/" + theme.mathjax.version + "/MathJax.js")
   script.
     MathJax.Hub.Config({
       menuSettings: {


### PR DESCRIPTION
使用前端渲染数学公式时会出现以下错误
:23 Uncaught ReferenceError: MathJax is not defined

相关代码：
<script async src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js"></script>
        <script>
            MathJax.Hub.Config({
                menuSettings: {
                    zoom: "None"
                },
                showMathMenu: false,
                jax: ["input/TeX", "output/CommonHTML"],
                extensions: ["tex2jax.js"],
                TeX: {
                    extensions: ["AMSmath.js", "AMSsymbols.js"],
                    equationNumbers: {
                        autoNumber: "AMS"
                    }
                },
                tex2jax: {
                    inlineMath: [["\\(", "\\)"]],
                    displayMath: [["\\[", "\\]"]]
                }
            });
        </script>

应该是异步导致的，取消异步后显示正常