### PR TITLE
fix: refresh page configuration during pjax navigation

### DIFF
--- a/layout/includes/js-data.pug
+++ b/layout/includes/js-data.pug
@@ -107,7 +107,7 @@ script window.addEventListener("load",() => {
   if pjax
     |pjax = new Pjax({
     |  cacheBust: false,
-    |  selectors: ['title','article','#aside-block','.pjax-js'],
+    |  selectors: ['title','article','#aside-block','.pjax-js','meta[name=page-config]'],
     |  switches: {'article': Pjax.switches.sideBySide},
     |  switchesOptions: {
     |    'article': {

--- a/layout/includes/meta-data.pug
+++ b/layout/includes/meta-data.pug
@@ -26,15 +26,20 @@ style.
     src: local('JetBrains Mono'), url('#{config.root}font/JetBrainsMono-Regular.woff2') format('woff2');
   }
 
-script.
+meta(name="page-config" content=JSON.stringify({ code_fold: page.code_fold || null }))
+script(class="pjax-js").
   var config = !{configs};
   var page_config = {
-    title: !{JSON.stringify(page.title)},
-    path: !{JSON.stringify(page.path)},
-    date: !{JSON.stringify(page.date)},
-    updated: !{JSON.stringify(page.updated)},
     code_fold: !{JSON.stringify(page.code_fold || null)}
   };
+  function updatePageConfig() {
+    var newPageConfig = document.querySelector('meta[name="page-config"]');
+    if (newPageConfig) {
+      page_config = JSON.parse(newPageConfig.content);
+    }
+  }
+  document.addEventListener('pjax:complete', function() { updatePageConfig(); });
+  updatePageConfig();
 if theme.waline && theme.waline.enable === true
   link(rel="stylesheet", href= url_for('//unpkg.com/@waline/client@v2/dist/waline.css'))
 link(type="text/css" rel="stylesheet" href=url_for("/lib/encrypt/hbe.style.css"))

--- a/layout/includes/pjax.pug
+++ b/layout/includes/pjax.pug
@@ -45,7 +45,7 @@ script window.addEventListener("load",() => {
   if pjax
     |pjax = new Pjax({
     |  cacheBust: false,
-    |  selectors: ['title','article','#aside-block','.pjax-js','data-pjax','.busuanzi'],
+    |  selectors: ['title','article','#aside-block','.pjax-js','data-pjax','.busuanzi','meta[name=page-config]'],
     |  switches: {'article': Pjax.switches.sideBySide},
     |  switchesOptions: {
     |    'article': {

--- a/source/js/_src/include/common/enviroment.d.ts
+++ b/source/js/_src/include/common/enviroment.d.ts
@@ -14,10 +14,6 @@ declare var config: {
 }
 
 declare var page_config: {
-  title: string
-  path: string
-  date: string
-  updated: string
   code_fold: number | null
 }
 


### PR DESCRIPTION
+ https://github.com/Yue-plus/hexo-theme-arknights/issues/194
+ https://github.com/Yue-plus/hexo-theme-arknights/issues/197
+ https://github.com/Yue-plus/hexo-theme-arknights/pull/195

上次 pr 没有关注 pjax 跳转页面时不会更新 js 数据，已修复。