### PR TITLE
feat: add footnotes rendering functionality and styles

### DIFF
--- a/scripts/filters/footnotes.js
+++ b/scripts/filters/footnotes.js
@@ -68,12 +68,12 @@ function renderFootnotes(text) {
       if (!indexMap[index]) {
         return '';
       }
-      const tooltip = handleHtml(marked.parse(indexMap[index].content));
+      const tooltip = replaceLink(handleHtml(marked.parse(indexMap[index].content)));
 
       return '<sup id="fnref:' + index + '">'
         + '<a href="#fn:' + index + '" rel="footnote">'
         + '<span class="footnote--top">[' + index + ']'
-        + '<content class="footnote--pop-ups">' + tooltip + '</content>'
+        + '<span class="footnote--pop-ups">' + tooltip + '</span>'
         + '</span></a></sup>';
     });
 
@@ -107,6 +107,10 @@ function renderFootnotes(text) {
 function handleHtml(text) {
   text = text.replace(/^(\s|<p>|<\/p>)+|(\s|<p>|<\/p>)+$/g, '');
   return text;
+}
+
+function replaceLink(text) {
+  return text.replace(/<a\b[^>]*>([\s\S]*?)<\/a>/gi, '<u>$1</u>');
 }
 
 hexo.extend.filter.register('before_post_render', data => {

--- a/scripts/filters/footnotes.js
+++ b/scripts/filters/footnotes.js
@@ -68,7 +68,7 @@ function renderFootnotes(text) {
       if (!indexMap[index]) {
         return '';
       }
-      const tooltip = replaceLink(handleHtml(marked.parse(indexMap[index].content)));
+      const tooltip = replaceLink(removeHtmlWhitespace(marked.parse(indexMap[index].content)));
 
       return '<sup id="fnref:' + index + '">'
         + '<a href="#fn:' + index + '" rel="footnote">'
@@ -89,7 +89,7 @@ function renderFootnotes(text) {
     html += footNote.index;
     html += '.</span>';
     html += '<span style="display: inline-block; vertical-align: top; margin-left: 10px;">';
-    html += handleHtml(marked.parse(footNote.content.trim()));
+    html += removeHtmlWhitespace(marked.parse(footNote.content.trim()));
     html += '<a href="#fnref:' + footNote.index + '"> ↩</a></span></li>';
   });
 
@@ -104,7 +104,7 @@ function renderFootnotes(text) {
   return text;
 }
 
-function handleHtml(text) {
+function removeHtmlWhitespace(text) {
   text = text.replace(/^(\s|<p>|<\/p>)+|(\s|<p>|<\/p>)+$/g, '');
   return text;
 }

--- a/scripts/filters/footnotes.js
+++ b/scripts/filters/footnotes.js
@@ -1,0 +1,119 @@
+// Fork from https://github.com/mintfog/hexo-theme-minimalism/
+
+/* global hexo */
+'use strict';
+
+/**
+ * Render markdown footnotes
+ * @param {String} text
+ * @returns {String} text
+ */
+function renderFootnotes(text) {
+  const marked = require('marked');
+  try {
+    marked.parse('# 123');
+  } catch (e) {
+    return text;
+  }
+
+  const footnotes = [];
+  const reFootnoteContent = /\[\^(\d+)]: ?([\S\s]+?)(?=\[\^(\d+)]|\n\n|$)/g;
+  const reInlineFootnote = /\[\^(\d+)]\((.+?)\)/g;
+  const reFootnoteIndex = /\[\^(\d+)]/g;
+  let html = '';
+
+  text = text.replace(/(<hexoPostRenderCodeBlock>[\S\s]+?<\/hexoPostRenderCodeBlock>)/g, (match, code) => {
+    return code.replace(reFootnoteIndex, (match, index) => {
+      return '[^<span>' + index + '</span>]';
+    });
+  });
+
+  // threat all inline footnotes
+  text = text.replace(reInlineFootnote, (match, index, content) => {
+    footnotes.push({
+      index: index,
+      content: content
+    });
+    // remove content of inline footnote
+    return '[^' + index + ']';
+  });
+
+  // threat all footnote contents
+  text = text.replace(reFootnoteContent, (match, index, content) => {
+    footnotes.push({
+      index: index,
+      content: content
+    });
+    // remove footnote content
+    return '';
+  });
+
+  // create map for looking footnotes array
+  function createLookMap(field) {
+    const map = {};
+    for (let i = 0; i < footnotes.length; i++) {
+      const item = footnotes[i];
+      const key = item[field];
+      map[key] = item;
+    }
+    return map;
+  }
+
+  const indexMap = createLookMap('index');
+
+  // render (HTML) footnotes reference
+  text = text.replace(reFootnoteIndex,
+    (match, index) => {
+
+      if (!indexMap[index]) {
+        return '';
+      }
+      const tooltip = handleHtml(marked.parse(indexMap[index].content));
+
+      return '<sup id="fnref:' + index + '">'
+        + '<a href="#fn:' + index + '" rel="footnote">'
+        + '<span class="footnote--top">[' + index + ']'
+        + '<content class="footnote--pop-ups">' + tooltip + '</content>'
+        + '</span></a></sup>';
+    });
+
+  // sort footnotes by their index
+  footnotes.sort((a, b) => {
+    return a.index - b.index;
+  });
+
+  // render footnotes (HTML)
+  footnotes.forEach(footNote => {
+    html += '<li id="fn:' + footNote.index + '">';
+    html += '<span style="display: inline-block; vertical-align: top; padding-right: 10px; margin-left: -40px">';
+    html += footNote.index;
+    html += '.</span>';
+    html += '<span style="display: inline-block; vertical-align: top; margin-left: 10px;">';
+    html += handleHtml(marked.parse(footNote.content.trim()));
+    html += '<a href="#fnref:' + footNote.index + '"> ↩</a></span></li>';
+  });
+
+  // add footnotes at the end of the content
+  if (footnotes.length) {
+    text += '<div id="footnotes">';
+    text += '<hr>';
+    text += '<div id="footnotelist">';
+    text += '<ol style="list-style: none; padding-left: 0; margin-left: 40px">' + html + '</ol>';
+    text += '</div></div>';
+  }
+  return text;
+}
+
+function handleHtml(text) {
+  text = text.replace(/^(\s|<p>|<\/p>)+|(\s|<p>|<\/p>)+$/g, '');
+  return text;
+}
+
+hexo.extend.filter.register('before_post_render', data => {
+  const themeConfig = hexo.theme.config;
+  if (themeConfig.footnote && themeConfig.footnote.enable) {
+    data.content = renderFootnotes(data.content);
+  }
+
+  return data;
+});

--- a/source/css/_core/core.styl
+++ b/source/css/_core/core.styl
@@ -1,5 +1,6 @@
 @import 'base'
 @import 'cursor'
+@import 'footnotes'
 @import 'scrollbar'
 
 @import 'aside/*'

--- a/source/css/_core/footnotes.styl
+++ b/source/css/_core/footnotes.styl
@@ -1,0 +1,87 @@
+// Fork from https://github.com/mintfog/hexo-theme-minimalism/
+
+.footnote--top {
+  position: relative;
+  display: inline-block;
+}
+
+.footnote--pop-ups, .footnote--top:before {
+  position: absolute;
+  -webkit-transform: translate3d(0, 0, 0);
+  -moz-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+  visibility: hidden;
+  opacity: 0;
+  z-index: 1000000;
+  pointer-events: none;
+  -webkit-transition: 0.3s ease;
+  -moz-transition: 0.3s ease;
+  transition: 0.3s ease;
+  -webkit-transition-delay: 0s;
+  -moz-transition-delay: 0s;
+  transition-delay: 0s;
+}
+
+.footnote--top:before {
+  transition-delay: 0s;
+  content: '';
+  background: 0 0;
+  border: 6px solid transparent;
+  bottom: 100%;
+  margin-bottom: -11px;
+  left: calc(50% - 6px);
+  border-top-color: #3986ac;
+}
+
+.footnote--top:hover:before {
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition-delay: 0.1s;
+  -moz-transition-delay: 0.1s;
+  transition-delay: 0.1s;
+  -webkit-transform: translateY(-8px);
+  -moz-transform: translateY(-8px);
+  transform: translateY(-8px);
+  z-index: 1000001;
+}
+
+.footnote--top:hover .footnote--pop-ups {
+  visibility: visible;
+  opacity: 1;
+  -webkit-transition-delay: 0.1s;
+  -moz-transition-delay: 0.1s;
+  transition-delay: 0.1s;
+  -webkit-transform: translateX(-50%) translateY(-8px);
+  -moz-transform: translateX(-50%) translateY(-8px);
+  transform: translateX(-50%) translateY(-8px);
+}
+
+.footnote--pop-ups {
+  border-radius: 4px;
+  background-color: #3986ac;
+  text-shadow: 0 -1px 0 #1a3c4d;
+  width: 150px;
+  white-space: normal;
+  line-height: 1.4em;
+  word-wrap: break-word;
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  transform: translateX(-50%);
+  bottom: 100%;
+  left: 50%;
+  color: #fff;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'Microsoft YaHei', '\5b8b\4f53', sans-serif;
+  box-shadow: 4px 4px 8px rgb(0 0 0 / 30%);
+
+  code {
+    background-color: #3986ac !important;
+  }
+}
+
+@media (min-width: 1200px) {
+  .footnote--pop-ups {
+    width: 200px;
+  }
+}

--- a/source/css/_page/post/post.styl
+++ b/source/css/_page/post/post.styl
@@ -22,7 +22,7 @@
   box-sizing border-box
   padding 20px 30px
   background-color var(--theme-bg-trans1)
-  overflow-x auto
+  overflow-x visible
   min-height calc(100vh - 20px)
   img
     max-width 100%


### PR DESCRIPTION
+ https://github.com/Yue-plus/hexo-theme-arknights/issues/21

参考 [mintfog/hexo-theme-minimalism](https://github.com/mintfog/hexo-theme-minimalism) 的脚注方案

需要在 config 中设置启用脚注

```yml
footnote:
  enable: true # 是否开启脚注解析
  markdown: false # 是否使用 markdown 解析脚注内容
```

---

1. 这里为了保证脚注可以完全显示，我对样式表做了修改（将 `overflow-x` 从 `auto` 改为 `visible`），不清楚是否存在副作用。
  https://github.com/weilycoder/hexo-theme-arknights/blob/708bddd786e77c12cb17aa8ab346188fda27d8c4/source/css/_page/post/post.styl#L25
2. 脚注中的链接在显示时会换成下划线

---

<img width="828" height="351" alt="图片" src="https://github.com/user-attachments/assets/30db254e-848d-4140-9ea2-a227f39988c1" />

<img width="348" height="151" alt="图片" src="https://github.com/user-attachments/assets/7566d1bd-4dcd-4de0-9901-a62986df69f5" />

<img width="1056" height="73" alt="图片" src="https://github.com/user-attachments/assets/585374d5-5da5-404d-838b-f0c98885b31f" />
