### PR TITLE
fix: 补全主题基础 SEO 元标签输出

### DIFF
--- a/layout/includes/aside.pug
+++ b/layout/includes/aside.pug
@@ -1,7 +1,7 @@
 aside
   #about
     a(href=config.root)#logo
-      img(src= asideLogo, alt= "Logo", style= {
+      img(src= asideLogo, alt= config.title || config.author || "Logo", style= {
         margin: theme.aside.logo_margin,
         'border-radius': theme.aside.logo_border_radius
       })

--- a/layout/includes/meta-data.pug
+++ b/layout/includes/meta-data.pug
@@ -2,9 +2,16 @@ meta(charset='UTF-8')
 meta(name='viewport' content='width=device-width, initial-scale=1.0')
 title= pageTitle
 - var keywords = page.keywords || page.tags && page.tags.map(function(t){return t.name}).join(',') || config.keywords || ''
+- var canonical = (typeof url !== 'undefined' && url) || (typeof full_url_for === 'function' ? full_url_for(page.path || '/') : '')
+- canonical = canonical ? canonical.replace(/index\.html$/, '') : canonical
+- if (!String(config.permalink || '').endsWith('.html')) canonical = canonical ? canonical.replace(/\.html$/, '') : canonical
 if keywords
   meta(name="keywords" content=typeof keywords === 'string' ? keywords : keywords.join(','))
 != open_graph({twitter_id: theme.twitter, google_plus: theme.google_plus, fb_admins: theme.fb_admins, fb_app_id: theme.fb_app_id})
+if canonical
+  link(rel="canonical" href=canonical)
+if page.noindex
+  meta(name="robots" content="noindex")
 link(
   rel="icon"
   type=(theme.favicon.type ? theme.favicon.type : "image/x-icon")


### PR DESCRIPTION
- 为页面增加 canonical 链接
- 在 noindex 页面输出 robots 元标签
- 为侧边栏 Logo 补充更有语义的 alt 文本