### PR TITLE
fix(aside): 修正侧栏邮箱社交链接的 mailto 处理

### DIFF
--- a/layout/includes/aside.pug
+++ b/layout/includes/aside.pug
@@ -13,6 +13,9 @@ aside
       #social-links
         each value, name in theme.social
           - let icon = value.split('||')[1].trim(), src = value.split('||')[0].trim()
+          - const hasUriScheme = /^[a-z][a-z0-9+.-]*:/i.test(src)
+          - const isEmailAddress = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(src)
+          - if (!hasUriScheme && isEmailAddress) src = `mailto:${src}`
           if icon.substring(0,2) === 'fa'
             a.social(href= src)
               i(alt= name,class= icon)


### PR DESCRIPTION
当 social 配置中的邮箱写成裸地址时，主题此前会直接输出到 href，
在 tags 等相对路径页面中会被浏览器解析成错误的相对链接并触发 404。

本次改动在渲染侧栏社交链接时识别未带 URI scheme 的邮箱地址，
自动补全为 mailto: 前缀，同时保持已有 http、https、mailto 等链接行为不变。